### PR TITLE
hwcomposer: Fix regression in hwc_sync

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,6 +38,9 @@ ifeq ($(call is-board-platform-in-list, mpq8092 msm_bronze msm8916), true)
     common_flags += -DVPU_TARGET
 endif
 
+ifeq ($(DISPLAY_DEBUG_SWAPINTERVAL),true)
+    common_flags += -DDEBUG_SWAPINTERVAL
+endif
 
 common_deps  :=
 kernel_includes :=

--- a/libgralloc/framebuffer.cpp
+++ b/libgralloc/framebuffer.cpp
@@ -64,6 +64,7 @@ struct fb_context_t {
 static int fb_setSwapInterval(struct framebuffer_device_t* dev,
                               int interval)
 {
+#ifdef DEBUG_SWAPINTERVAL
     //XXX: Get the value here and implement along with
     //single vsync in HWC
     char pval[PROPERTY_VALUE_MAX];
@@ -71,6 +72,7 @@ static int fb_setSwapInterval(struct framebuffer_device_t* dev,
     int property_interval = atoi(pval);
     if (property_interval >= 0)
         interval = property_interval;
+#endif
 
     fb_context_t* ctx = (fb_context_t*)dev;
     private_module_t* m = reinterpret_cast<private_module_t*>(

--- a/libhwcomposer/hwc_utils.cpp
+++ b/libhwcomposer/hwc_utils.cpp
@@ -1422,11 +1422,13 @@ int hwc_sync(hwc_context_t *ctx, hwc_display_contents_1_t* list, int dpy,
     data.retire_fen_fd = &retireFd;
     data.flags = MDP_BUF_SYNC_FLAG_RETIRE_FENCE;
 
+#ifdef DEBUG_SWAPINTERVAL
     char property[PROPERTY_VALUE_MAX];
     if(property_get("debug.egl.swapinterval", property, "1") > 0) {
         if(atoi(property) == 0)
             swapzero = true;
     }
+#endif
 
     bool isExtAnimating = false;
     if(dpy)


### PR DESCRIPTION
Hwc_sync is in the hotpath of display
rendering and gets called every ~17ms
during active rerendering.

Reading the property "debug.egl.swapinterval"
on every execution of hwc_sync causes a major
regression where the execution of hwc_sync
is much slower than it can be.

Doing I/O in hotpaths is inacceptable
and can cause an unnecessary constant
I/O load, additionally to the slowdown
in display rendering which was caused
in this case.

As solution, we condition this debugging
feature with "DISPLAY_DEBUG_SWAPINTERVAL",
so it can be enabled when explicitly needed.

Gralloc is not directly affected by the regression,
it was adjusted to match the conditioning
of the swapinterval debugging feature.

The HALs of msm8084,msm8226,msm8909,msm8960 and
msm8994 are affected by the regression and
get patched by this patch. Newer HALs
are not affected.

The stats contained in this patch were
collected using a Nextbit Robin (MSM8992),
which uses the msm8994 HAL.

Test: Manual testing for proper conditioning.
Test: Running full CTS suite without DISPLAY_DEBUG_SWAPINTERVAL set.

Change-Id: If08595d37ac0c1a19edd8d296289a21c9f95512a
Signed-off-by: Alex Naidis <alex.naidis@linux.com>